### PR TITLE
Fixed iOS 15 availability check for M1.

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -230,7 +230,7 @@ open class AnimatedImageView: UIImageView {
         if let currentFrame = animator?.currentFrameImage {
             layer.contents = currentFrame.cgImage
         } else {
-            if #available(iOS 15.0, *) {
+            if #available(iOS 15, *), ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 15 {
                 super.display(layer)
             } else {
                 layer.contents = image?.cgImage


### PR DESCRIPTION
https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes

From Xcode 13 change log;

> Availability checks in iPhone and iPad apps on a Mac with Apple silicon always return true. This causes iOS apps running in macOS 11 Big Sur to see iOS 15 APIs as available, resulting in crashes. This only affects apps available in the Mac App Store built with the “My Mac (Designed for iPhone)” or “My Mac (Designed for iPad)” run destination. It doesn’t affect Mac Catalyst apps. (83378814)
> 
> Workaround: Use the following code to check for iOS 15 availability:
>        ` if #available(iOS 15, *), ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 15 {`